### PR TITLE
Make sure blob is not empty before being processed

### DIFF
--- a/src/hooks/useVoiceVisualizer.tsx
+++ b/src/hooks/useVoiceVisualizer.tsx
@@ -47,7 +47,7 @@ function useVoiceVisualizer(): Controls {
   }, [prevTime, isPausedRecording, isRecordingInProgress]);
 
   useEffect(() => {
-    if (!recordedBlob) return;
+    if (!recordedBlob  || recordedBlob.size === 0) return;
 
     const processBlob = async () => {
       try {


### PR DESCRIPTION
**Problem Statement**
After recording audio, sometimes an "Error processing the audio blob: EncodingError:Decoding failed" error is encountered. Upon investigation, it was found that the processBlob function is being called even when the recordedBlob is empty (has a size of 0).

![image](https://github.com/YZarytskyi/react-voice-visualizer/assets/23127928/0af5b6d7-2ca4-4691-8c7d-2ff59f72a566)

**Solution**
To address this issue, an additional check is added to the useEffect hook that calls processBlob. The new check ensures that the recordedBlob not only exists but also has a non-zero size before invoking processBlob.

**Testing**
This change has been tested manually in a [Tauri](https://tauri.app/) project by recording audio and observing the error logs.