### PR TITLE
feat: add nonce field if available from meta tag

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -10,6 +10,14 @@ const injectCodeFunction = (cssCode) => {
 
     var elementStyle = document.createElement("style");
     elementStyle.appendChild(document.createTextNode(cssCode));
+
+    const nonce =
+      document.querySelector('meta[property="csp-nonce"]')?.getAttribute('nonce');
+
+    if (nonce) {
+      elementStyle.setAttribute('nonce', nonce);
+    }
+
     document.head.appendChild(elementStyle);
   } catch (e) {
     console.error("vite-plugin-css-injected-by-js", e);


### PR DESCRIPTION
- for security screens to pass script and style tags need to have a nonce set. more details [here](https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP)
- most libraries have a way to add a nonce, if a new style/script tag is created by the library
- this change will take the nonce value from the meta tag, in a similar way that [Vite sets the nonce tag](https://vite.dev/guide/features#content-security-policy-csp). 